### PR TITLE
Add carriage return

### DIFF
--- a/wipe_towers_v01.pl
+++ b/wipe_towers_v01.pl
@@ -690,7 +690,7 @@ sub insertWipeTowerE{
 		print travelToXYF($gcodeX[$e],$gcodeY[$e],$travelFeedrate);
 		print lower($travelLift);
 	}else{
-		print "; omitting wipe tower";
+		print "; omitting wipe tower\n";
 	}
 }
 


### PR DESCRIPTION
I think line 693 should have a trailing carriage return, otherwise the subsequent line of GCODE becomes part of the comment
