### PR TITLE
Fix gcodeRetraction initialization for more than 2 extruders

### DIFF
--- a/wipe_towers_v01.pl
+++ b/wipe_towers_v01.pl
@@ -1,9 +1,9 @@
+#!/usr/bin/perl -i
 # WIPE TOWERS v01
 # PERL POSTPROCESSOR FOR ADDING WIPE TOWERS TO SLIC3R
 # YUNOMAKE.COM
 # (c) Moritz Walter 2015
 
-#!/usr/bin/perl -i
 use strict;
 use warnings;
 use Math::Round;
@@ -93,13 +93,6 @@ my @endOfLayerLines=();
 
 my $bypass=0;
 
-for(my $i=0;$i<$extruders;$i++){
-	$linesByExtruder[$i]=();
-	$gcodeX[$i]=0;
-	$gcodeY[$i]=0;
-	$gcodeE[$i]=0;
-	$gcodeRetraction[$i]=0;
-}
 
 ##########
 # MAIN LOOP
@@ -107,9 +100,16 @@ for(my $i=0;$i<$extruders;$i++){
 
 while (<>) {
 	if($start==0){
-  	readParams($_);
-		evaluateLine($_);
-		print;
+  	    readParams($_);
+  	    for(my $i=0;$i<$extruders;$i++){
+  	    	$linesByExtruder[$i]=();
+	        $gcodeX[$i]=0;
+	        $gcodeY[$i]=0;
+	        $gcodeE[$i]=0;
+	        $gcodeRetraction[$i]=0;
+	    }
+	    evaluateLine($_);
+	    print;
 	}elsif($end==1){
   	print; # just print out everything after the end code marker
 	}elsif (/^T(\d)/){


### PR DESCRIPTION
Move the initialization loop after the readParams call so that the number of extruders given in the gcode comments is used correctly.
Moved perl hash-bang line to beginning of file so that it is recognized correctly when run from CLI.
